### PR TITLE
InspectionItemReducerの単体テストの実装

### DIFF
--- a/src/Web/ClientApp/src/test/InspectionItemReducer.test.js
+++ b/src/Web/ClientApp/src/test/InspectionItemReducer.test.js
@@ -1,11 +1,10 @@
-import React from 'react';
 import InspectionItemReducer, {
   setItemAction, updateFieldAction, setChoiceAction,
   addChoiceAction, removeChoiceAction, updateChoiceAction,
   TYPES
 } from '../inspection/InspectionItemReducer';
 
-it('setItemAction correctly', () => {
+it('set inspection item correctly', () => {
   const item = {
     inspection_item_id: 'id',
     inspection_content: 'content',
@@ -20,7 +19,7 @@ it('setItemAction correctly', () => {
   expect(actual).toStrictEqual(item);
 });
 
-it('updateFieldAction correctly', () => {
+it('update field correctly', () => {
   const event = {
     target: {
       name: 'inspection_content',
@@ -37,6 +36,25 @@ it('updateFieldAction correctly', () => {
   };
   const actual = InspectionItemReducer(item, action);
   expect(actual.inspection_content).toBe('update content');
+});
+
+it('do not update field if name is null', () => {
+  const event = {
+    target: {
+      name: null,
+      value: 'update content',
+    }
+  };
+  const action = updateFieldAction(event);
+  expect(action.type).toBe(TYPES.UPDATE_FIELD);
+  expect(action.payload.name).toBe(event.target.name);
+  expect(action.payload.value).toBe(event.target.value);
+
+  const item = {
+    inspection_content: 'content',
+  };
+  const actual = InspectionItemReducer(item, action);
+  expect(actual.inspection_content).toBe('content');
 });
 
 it('setChoiceAction correctly', () => {

--- a/src/Web/ClientApp/src/test/InspectionItemReducer.test.js
+++ b/src/Web/ClientApp/src/test/InspectionItemReducer.test.js
@@ -38,6 +38,28 @@ it('update field correctly', () => {
   expect(actual.inspection_content).toBe('update content');
 });
 
+it('update field correctly', () => {
+  const event = {
+    target: {
+      name: 'input_type',
+      value: '0',
+    }
+  };
+  const action = updateFieldAction(event);
+  expect(action.type).toBe(TYPES.UPDATE_FIELD);
+  expect(action.payload.name).toBe(event.target.name);
+  expect(action.payload.value).toBe(event.target.value);
+
+  const item = {
+    inspection_content: 'content',
+    input_type: '2',
+    choices: ['choice1', 'choice2']
+  };
+  const actual = InspectionItemReducer(item, action);
+  expect(actual.input_type).toBe('0');
+  expect(actual.choices.length).toBe(0);
+});
+
 it('do not update field if name is null', () => {
   const event = {
     target: {
@@ -57,7 +79,7 @@ it('do not update field if name is null', () => {
   expect(actual.inspection_content).toBe('content');
 });
 
-it('setChoiceAction correctly', () => {
+it('set choice correctly', () => {
   const choices = [
     'choice1',
     'choice2',
@@ -73,7 +95,7 @@ it('setChoiceAction correctly', () => {
   expect(actual.choices).toStrictEqual(['choice1', 'choice2']);
 });
 
-it('addChoiceAction correctly', () => {
+it('add choice correctly', () => {
   const action = addChoiceAction();
   expect(action.type).toBe(TYPES.ADD_CHOICE);
 
@@ -84,7 +106,7 @@ it('addChoiceAction correctly', () => {
   expect(actual.choices).toStrictEqual(['choice1', '']);
 });
 
-it('removeChoiceAction correctly', () => {
+it('remove choice correctly', () => {
   const index = 1;
   const action = removeChoiceAction(index);
   expect(action.type).toBe(TYPES.REMOVE_CHOICE);
@@ -97,7 +119,7 @@ it('removeChoiceAction correctly', () => {
   expect(actual.choices).toStrictEqual(['choice1']);
 });
 
-it('updateChoiceAction correctly', () => {
+it('update choice correctly', () => {
   const event = {
     target: {
       value: 'field_value',


### PR DESCRIPTION
## What this PR does / why we need it

InspectionItemReducerのカバレッジを高めるためテストを修正・追加