### PR TITLE
Use open API for inspection type controll

### DIFF
--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -167,8 +167,6 @@ paths:
                     description: type1
                   - inspection_type_id: 2
                     description: type2
-        "400":
-          description: バリデーションエラー or 業務エラー Bad Request
         "500":
           description: システムエラー Internal Server Error
     post:
@@ -187,8 +185,8 @@ paths:
               id: 0
               name: new type
       responses:
-        "202":
-          description: 正常系（非同期）Accepted
+        "201":
+          description: 正常系（非同期）Created
           content:
             application/json:
               schema:
@@ -223,6 +221,8 @@ paths:
               example:
                 inspection_group_id: 1
                 description: type name
+        "400":
+          description: 無効なID Bad Request
         "404":
           description: 対象リソースが存在しない Not Found
         "500":
@@ -239,9 +239,18 @@ paths:
           required: true
           schema:
             type: integer
+      requestBody:
+        description: inspection type to update
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InspectionType'
+            example:
+              id: 1
+              name: update type
       responses:
-        "202":
-          description: 正常系（非同期）Accepted
+        "201":
+          description: 正常系（非同期）Created
           content:
             application/json:
               schema:

--- a/src/Web/ClientApp/src/categories/InspectionTypeCategory.tsx
+++ b/src/Web/ClientApp/src/categories/InspectionTypeCategory.tsx
@@ -178,7 +178,7 @@ export const InspectionTypeCategory: FC = (): JSX.Element => {
                             data-testid={`remove-type-button-${index}`}
                             size="small"
                             color='secondary'
-                            onClick={() => handleDeleteItem(index)}
+                            onClick={() => handleDeleteItem(type.inspection_type_id)}
                           >
                             <CancelIcon />
                           </IconButton>

--- a/src/Web/ClientApp/src/categories/InspectionTypeCategory.tsx
+++ b/src/Web/ClientApp/src/categories/InspectionTypeCategory.tsx
@@ -11,6 +11,9 @@ import AddCircleIcon from '@material-ui/icons/AddCircle';
 import CancelIcon from '@material-ui/icons/Cancel';
 import EditIcon from '@material-ui/icons/Edit';
 import { InspectionType } from './../inspection/Types';
+import { InspectionTypesApi } from './../typescript-fetch/apis/InspectionTypesApi'
+
+const api = new InspectionTypesApi();
 
 export const InspectionTypeCategory: FC = (): JSX.Element => {
   const [open, setOpen] = useState(false);
@@ -25,9 +28,8 @@ export const InspectionTypeCategory: FC = (): JSX.Element => {
   const [errorMessage, setErrorMessage] = useState('');
 
   useEffect(() => {
-    fetch('inspectiontype')
-      .then(res => res.json())
-      .then((json: InspectionType[]) => setTypes(json))
+    api.inspectionTypesGet()
+      .then(res => setTypes(res))
       .catch(console.error);
   }, []);
 

--- a/src/Web/ClientApp/src/categories/InspectionTypeCategory.tsx
+++ b/src/Web/ClientApp/src/categories/InspectionTypeCategory.tsx
@@ -64,24 +64,14 @@ export const InspectionTypeCategory: FC = (): JSX.Element => {
 
   const handleRegistration = (): void => {
     if (isUpdate) {
-      fetch(`inspectiontype/${target.inspection_type_id}`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(target)
+      api.inspectionTypesInspectionTypeIdPut({
+        inspectionTypeId: target.inspection_type_id,
+        inspectionType: target
       })
-        .then((res) => {
-          if (!res.ok) {
-            setSuccessMessage('');
-            setErrorMessage('更新に失敗しました');
-          }
-          return res.json();
-        })
-        .then((json: InspectionType) => {
+        .then(res => {
           setTypes(types.map(x => {
-            if (x.inspection_type_id === json.inspection_type_id) {
-              return json;
+            if (x.inspection_type_id === res.inspection_type_id) {
+              return res;
             } else {
               return x;
             }
@@ -89,7 +79,11 @@ export const InspectionTypeCategory: FC = (): JSX.Element => {
           setSuccessMessage('更新に成功しました');
           setErrorMessage('');
         })
-        .catch(console.error);
+        .catch(error => {
+          console.log(error);
+          setSuccessMessage('');
+          setErrorMessage('更新に失敗しました');
+        });
     } else {
       api.inspectionTypesPost({
         'inspectionType': target

--- a/src/Web/ClientApp/src/categories/InspectionTypeCategory.tsx
+++ b/src/Web/ClientApp/src/categories/InspectionTypeCategory.tsx
@@ -91,26 +91,19 @@ export const InspectionTypeCategory: FC = (): JSX.Element => {
         })
         .catch(console.error);
     } else {
-      fetch('inspectiontype', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(target)
+      api.inspectionTypesPost({
+        'inspectionType': target
       })
-        .then((res) => {
-          if (!res.ok) {
-            setSuccessMessage('');
-            setErrorMessage('追加に失敗しました');
-          }
-          return res.json();
-        })
-        .then((json: InspectionType) => {
-          setTypes(types.concat(json));
+        .then(res => {
+          setTypes(types.concat(res));
           setSuccessMessage('追加に成功しました');
           setErrorMessage('');
         })
-        .catch(console.error);
+        .catch(error => {
+          console.error(error);
+          setSuccessMessage('');
+          setErrorMessage('追加に失敗しました');
+        })
     }
     setOpen(false);
   }

--- a/src/Web/ClientApp/src/categories/InspectionTypeCategory.tsx
+++ b/src/Web/ClientApp/src/categories/InspectionTypeCategory.tsx
@@ -113,23 +113,20 @@ export const InspectionTypeCategory: FC = (): JSX.Element => {
    * @param id Type ID to be deleted.
    */
   const handleDeleteItem = (id: number): void => {
-    fetch(`inspectiontype/${id}`, {
-      method: 'DELETE',
+    api.inspectionTypesInspectionTypeIdDelete({
+      'inspectionTypeId': id
     })
-      .then((res) => {
-        if (!res.ok) {
-          setSuccessMessage('');
-          setErrorMessage('削除に失敗しました');
-        }
-        return res.json();
-      })
-      .then((json: InspectionType) => {
+      .then(() => {
         setTypes(types.filter((x: InspectionType) =>
-          x.inspection_type_id !== json.inspection_type_id));
+          x.inspection_type_id !== id));
         setSuccessMessage('削除に成功しました');
         setErrorMessage('');
       })
-      .catch(console.error);
+      .catch(error => {
+        console.error(error);
+        setSuccessMessage('');
+        setErrorMessage('削除に失敗しました');
+      });
   }
 
   return (

--- a/src/Web/ClientApp/src/categories/InspectionTypeCategory.tsx
+++ b/src/Web/ClientApp/src/categories/InspectionTypeCategory.tsx
@@ -10,8 +10,8 @@ import MuiAlert from '@material-ui/lab/Alert';
 import AddCircleIcon from '@material-ui/icons/AddCircle';
 import CancelIcon from '@material-ui/icons/Cancel';
 import EditIcon from '@material-ui/icons/Edit';
-import { InspectionType } from './../inspection/Types';
-import { InspectionTypesApi } from './../typescript-fetch/apis/InspectionTypesApi'
+import { InspectionType } from './../typescript-fetch/models/InspectionType';
+import { InspectionTypesApi } from './../typescript-fetch/apis/InspectionTypesApi';
 
 const api = new InspectionTypesApi();
 

--- a/src/Web/ClientApp/src/components/Home.tsx
+++ b/src/Web/ClientApp/src/components/Home.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import {
@@ -15,7 +15,8 @@ import SearchIcon from '@material-ui/icons/Search';
 import { InspectionSheet, InspectionType } from '../inspection/Types';
 import { initialState } from '../inspection/operator/InspectionSheetOperator';
 import { InspectionGroup } from './../typescript-fetch/models/InspectionGroup';
-import { InspectionGroupsApi } from './../typescript-fetch/apis/InspectionGroupsApi'
+import { InspectionGroupsApi } from './../typescript-fetch/apis/InspectionGroupsApi';
+import { InspectionTypesApi } from './../typescript-fetch/apis/InspectionTypesApi';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -25,10 +26,11 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 );
 
+const groupApi = new InspectionGroupsApi();
+const typeApi = new InspectionTypesApi();
 
 export const Home: FC = (): JSX.Element => {
   const classes = useStyles();
-  const groupApi = useMemo(() => new InspectionGroupsApi(), []);
 
   const [groups, setGroups] = useState<InspectionGroup[]>([]);
   const [types, setTypes] = useState<InspectionType[]>([]);
@@ -49,11 +51,8 @@ export const Home: FC = (): JSX.Element => {
       .then(res => { setGroups(res); })
       .catch(console.error);
 
-    fetch('inspectiontype')
-      .then(res => res.json())
-      .then((json: InspectionType[]) => {
-        setTypes(json);
-      })
+    typeApi.inspectionTypesGet()
+      .then(res => { setTypes(res); })
       .catch(console.error);
 
     fetch('inspectionsheet')
@@ -64,7 +63,7 @@ export const Home: FC = (): JSX.Element => {
         setFilteredInspectionSheets(json);
       })
       .catch(console.error);
-  }, [groupApi]);
+  }, []);
 
   /**
    * Updates search option setting with given change event paramter.

--- a/src/Web/ClientApp/src/components/Home.tsx
+++ b/src/Web/ClientApp/src/components/Home.tsx
@@ -12,9 +12,10 @@ import CancelIcon from '@material-ui/icons/Cancel';
 import DetailsIcon from '@material-ui/icons/Details';
 import RotateLeftIcon from '@material-ui/icons/RotateLeft';
 import SearchIcon from '@material-ui/icons/Search';
-import { InspectionSheet, InspectionType } from '../inspection/Types';
+import { InspectionSheet } from '../inspection/Types';
 import { initialState } from '../inspection/operator/InspectionSheetOperator';
 import { InspectionGroup } from './../typescript-fetch/models/InspectionGroup';
+import { InspectionType } from './../typescript-fetch/models/InspectionType';
 import { InspectionGroupsApi } from './../typescript-fetch/apis/InspectionGroupsApi';
 import { InspectionTypesApi } from './../typescript-fetch/apis/InspectionTypesApi';
 

--- a/src/Web/ClientApp/src/inspection/Details.tsx
+++ b/src/Web/ClientApp/src/inspection/Details.tsx
@@ -8,11 +8,11 @@ import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
 import {
-  useInputTypes, InspectionSheet, Equipment, InspectionItem,
-  InspectionType
+  useInputTypes, InspectionSheet, Equipment, InspectionItem
 } from './Types';
 import { initialState } from './operator/InspectionSheetOperator';
 import { InspectionGroup } from './../typescript-fetch/models/InspectionGroup';
+import { InspectionType } from './../typescript-fetch/models/InspectionType';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/src/Web/ClientApp/src/inspection/Types.tsx
+++ b/src/Web/ClientApp/src/inspection/Types.tsx
@@ -26,11 +26,6 @@ export type ChoiceTemplate = {
   choices: Option[],
 };
 
-export type InspectionType = {
-  inspection_type_id: number,
-  description: string,
-};
-
 export type Choice = {
   choice_id: number,
   description: string,

--- a/src/Web/ClientApp/src/inspection/form/InspectionSheetForm.tsx
+++ b/src/Web/ClientApp/src/inspection/form/InspectionSheetForm.tsx
@@ -13,10 +13,10 @@ import { InspectionItemDialog } from '../dialog/InspectionItemDialog';
 import { InspectionSheetContext } from '../context/InspectionSheetContext';
 import { InspectionItemContext } from '../context/InspectionItemContext';
 import {
-  InspectionType,
   Equipment, InspectionItem, InspectionSheet
 } from '../Types';
 import { InspectionGroup } from './../../typescript-fetch/models/InspectionGroup';
+import { InspectionType } from './../../typescript-fetch/models/InspectionType';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/src/Web/ClientApp/src/typescript-fetch/apis/InspectionTypesApi.ts
+++ b/src/Web/ClientApp/src/typescript-fetch/apis/InspectionTypesApi.ts
@@ -30,6 +30,7 @@ export interface InspectionTypesInspectionTypeIdGetRequest {
 
 export interface InspectionTypesInspectionTypeIdPutRequest {
     inspectionTypeId: number;
+    inspectionType?: InspectionType;
 }
 
 export interface InspectionTypesPostRequest {
@@ -91,6 +92,7 @@ export interface InspectionTypesApiInterface {
      * 
      * @summary Updates the InspectionType model.
      * @param {number} inspectionTypeId inspection type ID to update
+     * @param {InspectionType} [inspectionType] inspection type to update
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof InspectionTypesApiInterface
@@ -221,11 +223,14 @@ export class InspectionTypesApi extends runtime.BaseAPI implements InspectionTyp
 
         const headerParameters: runtime.HTTPHeaders = {};
 
+        headerParameters['Content-Type'] = 'application/json';
+
         const response = await this.request({
             path: `/inspection-types/{inspection_type_id}`.replace(`{${"inspection_type_id"}}`, encodeURIComponent(String(requestParameters.inspectionTypeId))),
             method: 'PUT',
             headers: headerParameters,
             query: queryParameters,
+            body: InspectionTypeToJSON(requestParameters.inspectionType),
         });
 
         return new runtime.JSONApiResponse(response, (jsonValue) => InspectionTypeFromJSON(jsonValue));

--- a/src/Web/Controllers/InspectionGroupController.cs
+++ b/src/Web/Controllers/InspectionGroupController.cs
@@ -109,7 +109,7 @@ namespace InspectionManager.Web.Controllers
         /// <summary>
         /// Create a new InspectionGroup model
         /// </summary>
-        /// <param name="body">inspection group to create</param>
+        /// <param name="dto">inspection group to create</param>
         /// <response code="201">正常系（非同期）Created</response>
         /// <response code="400">バリデーションエラー or 業務エラー Bad Request</response>
         /// <response code="500">システムエラー Internal Server Error</response>
@@ -148,7 +148,7 @@ namespace InspectionManager.Web.Controllers
         /// Updates the InspectionGroup model.
         /// </summary>
         /// <param name="inspectionGroupId">inspection group ID to update</param>
-        /// <param name="body">inspection group to update</param>
+        /// <param name="dto">inspection group to update</param>
         /// <response code="201">正常系（非同期）Created</response>
         /// <response code="400">Invalid ID supplied</response>
         /// <response code="404">Not found</response>
@@ -160,7 +160,7 @@ namespace InspectionManager.Web.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public async Task<IActionResult> UpdateInspectionGroup([FromRoute][Required] int? inspectionGroupId, [FromBody] InspectionGroupDto dto)
+        public async Task<IActionResult> UpdateInspectionGroupAsync([FromRoute][Required] int? inspectionGroupId, [FromBody] InspectionGroupDto dto)
         {
             try
             {

--- a/src/Web/Controllers/InspectionTypeController.cs
+++ b/src/Web/Controllers/InspectionTypeController.cs
@@ -120,7 +120,6 @@ namespace InspectionManager.Web.Controllers
             try
             {
                 _logger.LogInformation($"try to get inspection type {inspectionTypeId}");
-
                 var result = _repository.GetInspectionType(inspectionTypeId);
                 if (result != null)
                 {
@@ -161,7 +160,6 @@ namespace InspectionManager.Web.Controllers
             {
                 if (inspectionGroupId.HasValue)
                 {
-
                     _logger.LogInformation($"try to update inspection type {dto.InspectionTypeId}");
                     if (_repository.InspectionTypeExists(dto.InspectionTypeId))
                     {
@@ -208,7 +206,6 @@ namespace InspectionManager.Web.Controllers
             {
                 if (inspectionTypeId.HasValue)
                 {
-
                     _logger.LogInformation($"try to delete inspection type {inspectionTypeId}");
                     if (!_repository.InspectionTypeExists(inspectionTypeId.Value))
                     {

--- a/src/Web/Controllers/InspectionTypeController.cs
+++ b/src/Web/Controllers/InspectionTypeController.cs
@@ -101,21 +101,34 @@ namespace InspectionManager.Web.Controllers
             }
         }
 
-        [HttpGet("{id:int}")]
-        public ActionResult<InspectionTypeDto> GetInspectionType(int id)
+        /// <summary>
+        /// Get InspectionType model by ID.
+        /// </summary>
+        /// <param name="inspectionTypeId">inspection type ID to get</param>
+        /// <response code="200">A single InspectionType model</response>
+        /// <response code="400">バリデーションエラー or 業務エラー Bad Request</response>
+        /// <response code="404">対象リソースが存在しない Not Found</response>
+        /// <response code="500">システムエラー Internal Server Error</response>
+        [HttpGet]
+        [Route("/v1/inspection-types/{inspectionTypeId}")]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(InspectionTypeDto))]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        public IActionResult GetInspectionType(int inspectionTypeId)
         {
             try
             {
-                _logger.LogInformation($"try to get inspection type {id}");
+                _logger.LogInformation($"try to get inspection type {inspectionTypeId}");
 
-                var result = _repository.GetInspectionType(id);
-                if (result == null)
+                var result = _repository.GetInspectionType(inspectionTypeId);
+                if (result != null)
                 {
-                    return NotFound();
+                    return Ok(result);
                 }
                 else
                 {
-                    return result;
+                    return NotFound($"type with Id = {inspectionTypeId} not found");
                 }
             }
             catch (Exception ex)

--- a/src/Web/Controllers/InspectionTypeController.cs
+++ b/src/Web/Controllers/InspectionTypeController.cs
@@ -63,6 +63,44 @@ namespace InspectionManager.Web.Controllers
             }
         }
 
+        /// <summary>
+        /// Create a new InspectionType model
+        /// </summary>
+        /// <param name="body">inspection type to create</param>
+        /// <response code="201">正常系（非同期）Created</response>
+        /// <response code="400">バリデーションエラー or 業務エラー Bad Request</response>
+        /// <response code="500">システムエラー Internal Server Error</response>
+        [HttpPost]
+        [Route("/v1/inspection-types")]
+        [Consumes(MediaTypeNames.Application.Json)]
+        [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(InspectionTypeDto))]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> CreateType(InspectionTypeDto? dto)
+        {
+            try
+            {
+                _logger.LogInformation("try to create inspection type");
+                if (dto == null)
+                {
+                    return BadRequest();
+                }
+                else
+                {
+                    var result = await _repository.CreateInspectionTypeAsync(dto);
+                    return CreatedAtAction(nameof(GetInspectionType),
+                    new { id = result.InspectionTypeId }, result);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                return StatusCode(StatusCodes.Status500InternalServerError,
+                    "Error creating new inspection types"
+                );
+            }
+        }
+
         [HttpGet("{id:int}")]
         public ActionResult<InspectionTypeDto> GetInspectionType(int id)
         {
@@ -85,32 +123,6 @@ namespace InspectionManager.Web.Controllers
                 _logger.LogError(ex.Message);
                 return StatusCode(StatusCodes.Status500InternalServerError,
                     "Error retrieving data from the database");
-            }
-        }
-
-        [HttpPost]
-        public async Task<ActionResult<InspectionTypeDto>> CreateType(InspectionTypeDto? dto)
-        {
-            try
-            {
-                _logger.LogInformation("try to create inspection type");
-                if (dto == null)
-                {
-                    return BadRequest();
-                }
-                else
-                {
-                    var result = await _repository.CreateInspectionTypeAsync(dto);
-                    return CreatedAtAction(nameof(GetInspectionType),
-                    new { id = result.InspectionTypeId }, result);
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex.Message);
-                return StatusCode(StatusCodes.Status500InternalServerError,
-                    "Error creating new inspection types"
-                );
             }
         }
 

--- a/src/Web/Controllers/InspectionTypeController.cs
+++ b/src/Web/Controllers/InspectionTypeController.cs
@@ -66,7 +66,7 @@ namespace InspectionManager.Web.Controllers
         /// <summary>
         /// Create a new InspectionType model
         /// </summary>
-        /// <param name="body">inspection type to create</param>
+        /// <param name="dto">inspection type to create</param>
         /// <response code="201">正常系（非同期）Created</response>
         /// <response code="400">バリデーションエラー or 業務エラー Bad Request</response>
         /// <response code="500">システムエラー Internal Server Error</response>
@@ -139,17 +139,45 @@ namespace InspectionManager.Web.Controllers
             }
         }
 
-        [HttpPut("{id:int}")]
-        public async Task<ActionResult<InspectionTypeDto>> UpdateInspectionType(InspectionTypeDto dto)
+        /// <summary>
+        /// Updates the InspectionType model.
+        /// </summary>
+        /// <param name="inspectionTypeId">inspection type ID to update</param>
+        /// <param name="dto">inspection type to update</param>
+        /// <response code="201">正常系（非同期）Created</response>
+        /// <response code="400">Invalid ID supplied</response>
+        /// <response code="404">Not found</response>
+        /// <response code="500">Internal Server Error</response>
+        [HttpPut]
+        [Route("/v1/inspection-types/{inspectionGroupId}")]
+        [Consumes(MediaTypeNames.Application.Json)]
+        [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(InspectionGroupDto))]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> UpdateInspectionTypeAsync([FromRoute][Required] int? inspectionGroupId, [FromBody] InspectionTypeDto dto)
         {
             try
             {
-                _logger.LogInformation($"try to update inspection type {dto.InspectionTypeId}");
-                if (!_repository.InspectionTypeExists(dto.InspectionTypeId))
+                if (inspectionGroupId.HasValue)
                 {
-                    return NotFound($"Type with Id = {dto.InspectionTypeId} not found");
+
+                    _logger.LogInformation($"try to update inspection type {dto.InspectionTypeId}");
+                    if (_repository.InspectionTypeExists(dto.InspectionTypeId))
+                    {
+                        var result = await _repository.UpdateInspectionTypeAsync(dto);
+                        return CreatedAtAction(nameof(GetInspectionType),
+                        new { id = result.InspectionTypeId }, result);
+                    }
+                    else
+                    {
+                        return NotFound($"Type with Id = {dto.InspectionTypeId} not found");
+                    }
                 }
-                return await _repository.UpdateInspectionTypeAsync(dto);
+                else
+                {
+                    return BadRequest();
+                }
             }
             catch (Exception ex)
             {

--- a/src/Web/Controllers/InspectionTypeController.cs
+++ b/src/Web/Controllers/InspectionTypeController.cs
@@ -159,17 +159,40 @@ namespace InspectionManager.Web.Controllers
             }
         }
 
-        [HttpDelete("{id:int}")]
-        public async Task<ActionResult<InspectionTypeDto>> DeleteInspectionTypeAsync(int id)
+        /// <summary>
+        /// Deletes the InspectionType model.
+        /// </summary>
+        /// <param name="inspectionTypeId">inspection type ID to delete</param>
+        /// <response code="204">No Content</response>
+        /// <response code="400">Invalid ID supplied</response>
+        /// <response code="404">Not found</response>
+        /// <response code="500">Internal Server Error</response>
+        [HttpDelete]
+        [Route("/v1/inspection-types/{inspectionTypeId}")]
+        [Consumes(MediaTypeNames.Application.Json)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> DeleteInspectionTypeAsync([FromRoute][Required] int? inspectionTypeId)
         {
             try
             {
-                _logger.LogInformation($"try to delete inspection type {id}");
-                if (!_repository.InspectionTypeExists(id))
+                if (inspectionTypeId.HasValue)
                 {
-                    return NotFound($"type with Id = {id} not found");
+
+                    _logger.LogInformation($"try to delete inspection type {inspectionTypeId}");
+                    if (!_repository.InspectionTypeExists(inspectionTypeId.Value))
+                    {
+                        return NotFound($"type with Id = {inspectionTypeId} not found");
+                    }
+                    await _repository.DeleteInspectionTypeAsync(inspectionTypeId.Value);
+                    return StatusCode(StatusCodes.Status204NoContent);
                 }
-                return await _repository.DeleteInspectionTypeAsync(id);
+                else
+                {
+                    return StatusCode(StatusCodes.Status400BadRequest);
+                }
             }
             catch (Exception ex)
             {

--- a/src/Web/Controllers/InspectionTypeController.cs
+++ b/src/Web/Controllers/InspectionTypeController.cs
@@ -6,6 +6,8 @@
 //
 
 using System;
+using System.ComponentModel.DataAnnotations;
+using System.Net.Mime;
 using System.Threading.Tasks;
 using InspectionManager.ApplicationCore.Dto;
 using InspectionManager.ApplicationCore.Interfaces;
@@ -36,8 +38,16 @@ namespace InspectionManager.Web.Controllers
             _logger = logger;
         }
 
+        /// <summary>
+        /// Get all inspection types.
+        /// </summary>
+        /// <response code="200">A JSON array of InspectionType model</response>
+        /// <response code="500">システムエラー Internal Server Error</response>
         [HttpGet]
-        public ActionResult<InspectionTypeDto> GetAllTypes()
+        [Route("/v1/inspection-types")]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(InspectionTypeDto))]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        public IActionResult GetAllTypes()
         {
             try
             {


### PR DESCRIPTION
## What this PR does / why we need it

拡張性向上のために，inspection type のCRUD処理を
open APIでの実装に変更

## Which issue(s) this PR fixes

Fixes #
