### PR TITLE
ORマッパーの利用方法の修正

### DIFF
--- a/src/Infrastructure/CategoryRepository.cs
+++ b/src/Infrastructure/CategoryRepository.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
+using AutoMapper.QueryableExtensions;
 using InspectionManager.ApplicationCore.Dto;
 using InspectionManager.ApplicationCore.Entities;
 using InspectionManager.ApplicationCore.Interfaces;
@@ -44,7 +45,7 @@ namespace InspectionManager.Infrastructure
             if (_context.InspectionGroups != null)
             {
                 return _context.InspectionGroups
-                    .Select(x => _mapper.Map<InspectionGroupDto>(x))
+                    .ProjectTo<InspectionGroupDto>(_mapper.ConfigurationProvider)
                     .ToList();
             }
             else
@@ -58,15 +59,11 @@ namespace InspectionManager.Infrastructure
         {
             if (_context.InspectionGroups != null)
             {
-                var entity = _context.InspectionGroups.Single(x => x.InspectionGroupId == id);
-                if (entity != null)
-                {
-                    return _mapper.Map<InspectionGroupDto>(entity);
-                }
-                else
-                {
-                    return null;
-                }
+                var dto = _context.InspectionGroups
+                    .Where(x => x.InspectionGroupId == id)
+                    .ProjectTo<InspectionGroupDto>(_mapper.ConfigurationProvider)
+                    .Single();
+                return dto;
             }
             else
             {
@@ -150,7 +147,7 @@ namespace InspectionManager.Infrastructure
             if (_context.InspectionTypes != null)
             {
                 return _context.InspectionTypes
-                    .Select(x => _mapper.Map<InspectionTypeDto>(x))
+                    .ProjectTo<InspectionTypeDto>(_mapper.ConfigurationProvider)
                     .ToList();
             }
             else
@@ -164,15 +161,11 @@ namespace InspectionManager.Infrastructure
         {
             if (_context.InspectionTypes != null)
             {
-                var entity = _context.InspectionTypes.Single(x => x.InspectionTypeId == id);
-                if (entity != null)
-                {
-                    return _mapper.Map<InspectionTypeDto>(entity);
-                }
-                else
-                {
-                    return null;
-                }
+                var dto = _context.InspectionTypes
+                    .Where(x => x.InspectionTypeId == id)
+                    .ProjectTo<InspectionTypeDto>(_mapper.ConfigurationProvider)
+                    .Single();
+                return dto;
             }
             else
             {
@@ -257,13 +250,7 @@ namespace InspectionManager.Infrastructure
             if (_context.ChoiceTemplates != null)
             {
                 var templates = _context.ChoiceTemplates
-                    .Select(x => new ChoiceTemplateDto
-                    {
-                        ChoiceTemplateId = x.ChoiceTemplateId,
-                        Choices = x.Choices.Select(y =>
-                            _mapper.Map<OptionDto>(y)
-                        ).ToList()
-                    })
+                    .ProjectTo<ChoiceTemplateDto>(_mapper.ConfigurationProvider)
                     .ToList();
                 return templates;
             }
@@ -280,8 +267,8 @@ namespace InspectionManager.Infrastructure
             {
                 return _context.ChoiceTemplates
                     .Where(x => x.ChoiceTemplateId == id)
-                    .Select(x => _mapper.Map<ChoiceTemplateDto>(x))
-                    .First();
+                    .ProjectTo<ChoiceTemplateDto>(_mapper.ConfigurationProvider)
+                    .Single();
             }
             else
             {

--- a/src/Infrastructure/InspectionSheetRepository.cs
+++ b/src/Infrastructure/InspectionSheetRepository.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
+using AutoMapper.QueryableExtensions;
 using InspectionManager.ApplicationCore.Dto;
 using InspectionManager.ApplicationCore.Entities;
 using InspectionManager.ApplicationCore.Interfaces;
@@ -44,10 +45,10 @@ namespace InspectionManager.Infrastructure
         {
             if (_context.InspectionSheets != null)
             {
-                var entities = _context.InspectionSheets
-                    .Select(x => _mapper.Map<InspectionSheetDto>(x))
+                var dto = _context.InspectionSheets
+                    .ProjectTo<InspectionSheetDto>(_mapper.ConfigurationProvider)
                     .ToList();
-                return entities;
+                return dto;
             }
             else
             {
@@ -60,48 +61,10 @@ namespace InspectionManager.Infrastructure
         {
             if (_context.InspectionSheets != null)
             {
-                var entity = _context.InspectionSheets.Single(x => x.SheetId == id);
-                if (_context.InspectionGroups != null)
-                {
-                    entity.InspectionGroup = _context.InspectionGroups
-                        .Single(x => x.InspectionGroupId == entity.InspectionGroupId);
-                }
-                if (_context.InspectionTypes != null)
-                {
-                    entity.InspectionType = _context.InspectionTypes
-                        .Single(x => x.InspectionTypeId == entity.InspectionTypeId);
-                }
-                if (_context.Equipments != null)
-                {
-                    entity.Equipments = _context.Equipments
-                        .Where(x => x.InspectionSheetId == entity.SheetId)
-                        .OrderBy(x => x.OrderIndex)
-                        .ToList();
-                }
-                if (_context.InspectionItems != null)
-                {
-                    foreach (var equipment in entity.Equipments)
-                    {
-                        equipment.InspectionItems = _context.InspectionItems
-                            .Where(x => x.EquipmentId == equipment.EquipmentId)
-                            .OrderBy(x => x.OrderIndex)
-                            .ToList();
-                    }
-                }
-                if (_context.Choices != null)
-                {
-                    foreach (var equipment in entity.Equipments)
-                    {
-                        foreach (var inspectionItem in equipment.InspectionItems)
-                        {
-                            inspectionItem.Choices = _context.Choices
-                                .Where(x => x.InspectionItemId == inspectionItem.InspectionItemId)
-                                .OrderBy(x => x.OrderIndex)
-                                .ToList();
-                        }
-                    }
-                }
-                var dto = _mapper.Map<InspectionSheetDto>(entity);
+                var dto = _context.InspectionSheets
+                    .Where(x => x.SheetId == id)
+                    .ProjectTo<InspectionSheetDto>(_mapper.ConfigurationProvider)
+                    .Single();
 
                 return dto;
             }


### PR DESCRIPTION
## What this PR does / why we need it

Automapperとentity framework coreを組み合わせる場合，
Map関数だと別テーブルの値を読み込むことができないため，
ProjectTo関数を用いてデータを読み込むように処理を変更

## Which issue(s) this PR fixes

Fixes #
